### PR TITLE
Put verilator options in double quotes

### DIFF
--- a/lib/verilog_axi_bb_impl.cc
+++ b/lib/verilog_axi_bb_impl.cc
@@ -355,7 +355,7 @@ namespace gr {
       cmd += std::string(" ") + "USER_CPP_FILENAME=" + CPP_TEMPLATE_NAME;
       cmd += std::string(" ") + " M_DIR=" + M_dir;
       // cmd += verilator_options:
-      cmd += std::string(" ") + "VERILATOR_OPTIONS=" + this->verilator_options;
+      cmd += std::string(" ") + "VERILATOR_OPTIONS=\"" + this->verilator_options + "\"";
       cmd += ENTER;
 
       cmd += ENTER;

--- a/lib/verilog_axi_cc_impl.cc
+++ b/lib/verilog_axi_cc_impl.cc
@@ -355,7 +355,7 @@ namespace gr {
       cmd += std::string(" ") + "USER_CPP_FILENAME=" + CPP_TEMPLATE_NAME;
       cmd += std::string(" ") + " M_DIR=" + M_dir;
       // cmd += verilator_options:
-      cmd += std::string(" ") + "VERILATOR_OPTIONS=" + this->verilator_options;
+      cmd += std::string(" ") + "VERILATOR_OPTIONS=\"" + this->verilator_options + "\"";
       cmd += ENTER;
 
       cmd += ENTER;

--- a/lib/verilog_axi_ff_impl.cc
+++ b/lib/verilog_axi_ff_impl.cc
@@ -355,7 +355,7 @@ namespace gr {
       cmd += std::string(" ") + "USER_CPP_FILENAME=" + CPP_TEMPLATE_NAME;
       cmd += std::string(" ") + " M_DIR=" + M_dir;
       // cmd += verilator_options:
-      cmd += std::string(" ") + "VERILATOR_OPTIONS=" + this->verilator_options;
+      cmd += std::string(" ") + "VERILATOR_OPTIONS=\"" + this->verilator_options + "\"";
       cmd += ENTER;
 
       cmd += ENTER;

--- a/lib/verilog_axi_ii_impl.cc
+++ b/lib/verilog_axi_ii_impl.cc
@@ -355,7 +355,7 @@ namespace gr {
       cmd += std::string(" ") + "USER_CPP_FILENAME=" + CPP_TEMPLATE_NAME;
       cmd += std::string(" ") + " M_DIR=" + M_dir;
       // cmd += verilator_options:
-      cmd += std::string(" ") + "VERILATOR_OPTIONS=" + this->verilator_options;
+      cmd += std::string(" ") + "VERILATOR_OPTIONS=\"" + this->verilator_options + "\"";
       cmd += ENTER;
 
       cmd += ENTER;

--- a/lib/verilog_axi_ss_impl.cc
+++ b/lib/verilog_axi_ss_impl.cc
@@ -355,7 +355,7 @@ namespace gr {
       cmd += std::string(" ") + "USER_CPP_FILENAME=" + CPP_TEMPLATE_NAME;
       cmd += std::string(" ") + " M_DIR=" + M_dir;
       // cmd += verilator_options:
-      cmd += std::string(" ") + "VERILATOR_OPTIONS=" + this->verilator_options;
+      cmd += std::string(" ") + "VERILATOR_OPTIONS=\"" + this->verilator_options + "\"";
       cmd += ENTER;
 
       cmd += ENTER;


### PR DESCRIPTION
This allows multiple start-up options separated by white space for Verilator.